### PR TITLE
Add GitHub Pages deployment pipeline using Jekyll

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,47 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This creates a github pages page from the read me every push to main: 

https://arran4.github.io/go-gui-projects/

This adds a GitHub Actions workflow in `.github/workflows/pages.yml` to automatically build and deploy the repository's Markdown files (e.g. README.md) to GitHub Pages using Jekyll. This pipeline only creates files within the `.github` directory as requested.

Toggle this option before merging (or go to actions and click "rerun failed jobs")

<img width="1299" height="1084" alt="image" src="https://github.com/user-attachments/assets/79b5a490-b737-48a8-8284-ddb2f65bab7a" />

Then once done you can check this box here:

<img width="1071" height="645" alt="image" src="https://github.com/user-attachments/assets/200cd0d1-1524-4cf2-9025-aafddfb92018" />
